### PR TITLE
feat: cgo-enabled flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /go/src/github.com/BuxOrg/bux-server
 
 COPY . ./
 
+ENV CGO_ENABLED=1
+
 # Build binary
 RUN GOOS=linux go build -o bux cmd/server/main.go
 


### PR DESCRIPTION
This flag is necessary after updating to newest version of bux - instead we have an error:
/bux: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /bux)
/bux: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by /bux)
/bux: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /bux)