### PR TITLE
feat(BUX-116): txs mapping for admin panel

### DIFF
--- a/actions/admin/transactions.go
+++ b/actions/admin/transactions.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/BuxOrg/bux"
+	buxmodels "github.com/BuxOrg/bux-models"
 	"github.com/BuxOrg/bux-server/actions"
 	"github.com/BuxOrg/bux-server/mappings"
 	"github.com/julienschmidt/httprouter"
@@ -46,8 +47,13 @@ func (a *Action) transactionsSearch(w http.ResponseWriter, req *http.Request, _ 
 		return
 	}
 
+	contracts := make([]*buxmodels.Transaction, 0)
+	for _, transaction := range transactions {
+		contracts = append(contracts, mappings.MapToTransactionContractForAdmin(transaction))
+	}
+
 	// Return response
-	apirouter.ReturnResponse(w, req, http.StatusOK, transactions)
+	apirouter.ReturnResponse(w, req, http.StatusOK, contracts)
 }
 
 // transactionsCount will count all transactions filtered by metadata

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/99designs/gqlgen v0.17.36
 	github.com/BuxOrg/bux v0.5.12
-	github.com/BuxOrg/bux-models v0.1.1
+	github.com/BuxOrg/bux-models v0.1.2
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/BuxOrg/bux v0.5.12 h1:lF75iwcR/VAQ5vjim3YJ2TsgtRSUUBrAbfgsFlhYIZY=
 github.com/BuxOrg/bux v0.5.12/go.mod h1:6iNxLzkECsFirgcIz6BIxqiBJUM+aGOqDKKqxxX4Jg8=
-github.com/BuxOrg/bux-models v0.1.1 h1:BqKPbBnk5G943SR7Bh7UvyNqG42970ELGyvTciDX2/E=
-github.com/BuxOrg/bux-models v0.1.1/go.mod h1:nH3MOdsIPPerBPOiEvwA01yTeArYtBk+PtDo7E+vPCk=
+github.com/BuxOrg/bux-models v0.1.2 h1:MUtqwnhJuSNaXXglMtTltVh+QYTyQPV6wBERogQmMYM=
+github.com/BuxOrg/bux-models v0.1.2/go.mod h1:nH3MOdsIPPerBPOiEvwA01yTeArYtBk+PtDo7E+vPCk=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DataDog/datadog-go v3.7.1+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=

--- a/mappings/transaction.go
+++ b/mappings/transaction.go
@@ -30,6 +30,35 @@ func MapToTransactionContract(t *bux.Transaction) *buxmodels.Transaction {
 	}
 
 	processMetadata(t, t.XPubID, &model)
+	processOutputValue(t, t.XPubID, &model)
+
+	return &model
+}
+
+// MapToTransactionContractForAdmin will map the model from bux to the bux-models contract for admin
+func MapToTransactionContractForAdmin(t *bux.Transaction) *buxmodels.Transaction {
+	if t == nil {
+		return nil
+	}
+
+	model := buxmodels.Transaction{
+		Model:           *common.MapToContract(&t.Model),
+		ID:              t.ID,
+		Hex:             t.Hex,
+		XpubInIDs:       t.XpubInIDs,
+		XpubOutIDs:      t.XpubOutIDs,
+		BlockHash:       t.BlockHash,
+		BlockHeight:     t.BlockHeight,
+		Fee:             t.Fee,
+		NumberOfInputs:  t.NumberOfInputs,
+		NumberOfOutputs: t.NumberOfOutputs,
+		DraftID:         t.DraftID,
+		TotalValue:      t.TotalValue,
+		Status:          string(t.Status),
+		Outputs:         t.XpubOutputValue,
+	}
+
+	processMetadata(t, t.XPubID, &model)
 
 	return &model
 }
@@ -43,7 +72,9 @@ func processMetadata(t *bux.Transaction, xpubID string, model *buxmodels.Transac
 			model.Model.Metadata[key] = value
 		}
 	}
+}
 
+func processOutputValue(t *bux.Transaction, xpubID string, model *buxmodels.Transaction) {
 	model.OutputValue = int64(0)
 	if len(t.XpubOutputValue) > 0 && t.XpubOutputValue[xpubID] != 0 {
 		model.OutputValue = t.XpubOutputValue[xpubID]


### PR DESCRIPTION
Updated version of bux-models.
/v1/admin/transactions/search starts returning txs in bux-models format and outputValue replaced with list of outputs for admin as it was mentioned in https://github.com/BuxOrg/bux-models/pull/4