### PR TITLE
feat(BUX-234): delete ProcessMempoolOnConnect from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -121,7 +121,6 @@ type (
 		LoadMonitoredDestinations   bool    `json:"load_monitored_destinations" mapstructure:"load_monitored_destinations"`     // Whether to load monitored destinations`
 		MaxNumberOfDestinations     int     `json:"max_number_of_destinations" mapstructure:"max_number_of_destinations"`       // how many destinations can the filter hold (default: 100,000)
 		MonitorDays                 int     `json:"monitor_days" mapstructure:"monitor_days"`                                   // how many days in the past should we monitor an address (default: 7)
-		ProcessMempoolOnConnect     bool    `json:"process_mempool_on_connect" mapstructure:"process_mempool_on_connect"`       // Whether to process all transactions in the mempool when connecting to centrifuge server
 		ProcessorType               string  `json:"processor_type" mapstructure:"processor_type"`                               // Type of processor to start monitor with. Default: bloom
 		SaveTransactionDestinations bool    `json:"save_transaction_destinations" mapstructure:"save_transaction_destinations"` // Whether to save destinations on monitored transactions
 	}

--- a/config/envs/development.json
+++ b/config/envs/development.json
@@ -50,7 +50,6 @@
     "load_monitored_destinations": false,
     "max_number_of_destinations": 100000,
     "monitor_days": 7,
-    "process_mempool_on_connect": true,
     "processor_type": "bloom",
     "save_destinations": true
   },

--- a/config/envs/docker-compose.json
+++ b/config/envs/docker-compose.json
@@ -43,7 +43,6 @@
     "load_monitored_destinations": false,
     "max_number_of_destinations": 100000,
     "monitor_days": 7,
-    "process_mempool_on_connect": true,
     "processor_type": "bloom",
     "save_destinations": true
   },

--- a/config/envs/production.json
+++ b/config/envs/production.json
@@ -43,7 +43,6 @@
     "load_monitored_destinations": false,
     "max_number_of_destinations": 100000,
     "monitor_days": 7,
-    "process_mempool_on_connect": true,
     "processor_type": "bloom",
     "save_destinations": true
   },

--- a/config/envs/staging.json
+++ b/config/envs/staging.json
@@ -43,7 +43,6 @@
     "load_monitored_destinations": false,
     "max_number_of_destinations": 100000,
     "monitor_days": 7,
-    "process_mempool_on_connect": true,
     "processor_type": "bloom",
     "save_destinations": true
   },

--- a/config/envs/test.json
+++ b/config/envs/test.json
@@ -48,7 +48,6 @@
     "load_monitored_destinations": false,
     "max_number_of_destinations": 100000,
     "monitor_days": 7,
-    "process_mempool_on_connect": true,
     "processor_type": "bloom",
     "save_destinations": true
   },

--- a/config/services.go
+++ b/config/services.go
@@ -283,7 +283,6 @@ func (s *AppServices) loadBux(ctx context.Context, appConfig *AppConfig, testMod
 			MaxNumberOfDestinations:     appConfig.Monitor.MaxNumberOfDestinations,
 			SaveTransactionDestinations: appConfig.Monitor.SaveTransactionDestinations,
 			LoadMonitoredDestinations:   appConfig.Monitor.LoadMonitoredDestinations,
-			ProcessMempoolOnConnect:     appConfig.Monitor.ProcessMempoolOnConnect,
 		}))
 	}
 


### PR DESCRIPTION
<img width="825" alt="Screenshot 2023-09-20 at 08 50 17" src="https://github.com/BuxOrg/bux-server/assets/123358309/efad2774-c1b6-4a52-9b93-fd389f3c8ca6">
ProcessMempoolOnConnect was deleted in bux in https://github.com/BuxOrg/bux/pull/401.
So we need to delete it from bux-server too 
