### PR TITLE
chore(BUX-431) Configure & select `mapi` or `arc` with arc-gorillapool as default

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -78,11 +78,7 @@ _nodes:
     protocol: arc
     apis:
         - arc_url: https://arc.gorillapool.io
-          mapi_url: https://merchantapi.gorillapool.io
-          minerid: 03ad780153c47df915b3d2e23af727c68facaca4facd5f155bf5018b979b9aeb83
-          token: ""
-    mapi:
-        use_fee_quotes: true
+          token:
 # Prefixed with "_", because it's unused by default
 _notifications:
   enabled: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,14 +75,14 @@ _new_relic:
   license_key: BOGUS-LICENSE-KEY-1234567890987654321234
 # Prefixed with "_", because it will be configured by default
 _nodes:
-  protocol: arc
-  apis:
-    - arc_url: https://arc.gorillapool.io
-      mapi_url: https://merchantapi.gorillapool.io
-      minerid: 03ad780153c47df915b3d2e23af727c68facaca4facd5f155bf5018b979b9aeb83
-      token: ""
-  mapi:
-    use_fee_quotes: true
+    protocol: arc
+    apis:
+        - arc_url: https://arc.gorillapool.io
+          mapi_url: https://merchantapi.gorillapool.io
+          minerid: 03ad780153c47df915b3d2e23af727c68facaca4facd5f155bf5018b979b9aeb83
+          token: ""
+    mapi:
+        use_fee_quotes: true
 # Prefixed with "_", because it's unused by default
 _notifications:
   enabled: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,7 +82,7 @@ _nodes:
       minerid: 03ad780153c47df915b3d2e23af727c68facaca4facd5f155bf5018b979b9aeb83
       token: ""
   mapi:
-    - use_fee_quotes: true
+    use_fee_quotes: true
 # Prefixed with "_", because it's unused by default
 _notifications:
   enabled: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,10 +75,10 @@ _new_relic:
   license_key: BOGUS-LICENSE-KEY-1234567890987654321234
 # Prefixed with "_", because it will be configured by default
 _nodes:
-    protocol: arc
-    apis:
-        - arc_url: https://arc.gorillapool.io
-          token:
+  protocol: arc
+  apis:
+    - arc_url: https://arc.gorillapool.io
+      token:
 # Prefixed with "_", because it's unused by default
 _notifications:
   enabled: false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -73,16 +73,16 @@ _new_relic:
   domain_name: domain.com
   enabled: false
   license_key: BOGUS-LICENSE-KEY-1234567890987654321234
-nodes:
-  broadcast_client_apis: []
-  minercraft_api: mAPI
-  minercraft_custom_apis:
-    - minerid: 03e92d3e5c3f7bd945dfbf48e7a99393b1bfb3f11f380ae30d286e7ff2aec5a270
-      apis:
-        - token: mainnet_3af382fadbc448b15cc4133242ac2621
-          url: https://merchantapi.taal.com
-          type: mAPI
-  use_mapi_fee_quotes: true
+# Prefixed with "_", because it will be configured by default
+_nodes:
+  protocol: arc
+  apis:
+    - arc_url: https://arc.gorillapool.io
+      mapi_url: https://merchantapi.gorillapool.io
+      minerid: 03ad780153c47df915b3d2e23af727c68facaca4facd5f155bf5018b979b9aeb83
+      token: ""
+  mapi:
+    - use_fee_quotes: true
 # Prefixed with "_", because it's unused by default
 _notifications:
   enabled: false

--- a/config/config.go
+++ b/config/config.go
@@ -155,12 +155,12 @@ type NodesConfig struct {
 
 // MinerAPI holds connection info for a single miner endpoint
 type MinerAPI struct {
-	Token   string `json:"token,omitempty"`
-	ArcURL  string `json:"arc_url,omitempty"`
-	MapiURL string `json:"mapi_url,omitempty"`
+	Token   string `json:"token" mapstructure:"token"`
+	ArcURL  string `json:"arc_url" mapstructure:"arc_url"`
+	MapiURL string `json:"mapi_url" mapstructure:"mapi_url"`
 
 	// MinerID is not used with ARC potocol
-	MinerID string `json:"minerid,omitempty"`
+	MinerID string `json:"minerid" mapstructure:"minerid"`
 }
 
 // MapiConfig holds mApi-specific configuration

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/BuxOrg/bux/taskmanager"
 	"github.com/mrz1836/go-cachestore"
 	"github.com/mrz1836/go-datastore"
-	"github.com/tonicpow/go-minercraft/v2"
 )
 
 // Config constants used for bux-server
@@ -149,20 +148,24 @@ type NewRelicConfig struct {
 
 // NodesConfig consists of blockchain nodes (such as Minercraft and Arc) configuration
 type NodesConfig struct {
-	// UseMapiFeeQuotes is a flag that says whether bux should use fee quotes from mAPI.
-	UseMapiFeeQuotes bool `json:"use_mapi_fee_quotes" mapstructure:"use_mapi_fee_quotes"`
-	// MinercraftAPI is a string that holds the url of mAPI.
-	MinercraftAPI string `json:"minercraft_api" mapstructure:"minercraft_api"`
-	// MinercraftCustomAPIs is a slice of Minercraft custom miners APIs.
-	MinercraftCustomAPIs []*minercraft.MinerAPIs `json:"minercraft_custom_apis" mapstructure:"minercraft_custom_apis"`
-	// BroadcastClientAPIs is a slice of Broadcast Client custom miners APIs.
-	BroadcastClientAPIs []*BroadcastClientAPI `json:"broadcast_client_apis" mapstructure:"broadcast_client_apis"`
+	Protocol NodesProtocol `json:"protocol" mapstructure:"protocol"`
+	Apis     []*MinerAPI   `json:"apis" mapstructure:"apis"`
+	Mapi     *MapiConfig   `json:"mapi" mapstructure:"mapi"`
 }
 
-// BroadcastClientAPI is a URL-Token pair for Broadcast Client; Token is optional
-type BroadcastClientAPI struct {
-	Token string `json:"token,omitempty"`
-	URL   string `json:"url,omitempty"`
+// MinerAPI holds connection info for a single miner endpoint
+type MinerAPI struct {
+	Token   string `json:"token,omitempty"`
+	ArcURL  string `json:"arc_url,omitempty"`
+	MapiURL string `json:"mapi_url,omitempty"`
+
+	// MinerID is not used with ARC potocol
+	MinerID string `json:"minerid,omitempty"`
+}
+
+// MapiConfig holds mApi-specific configuration
+type MapiConfig struct {
+	UseFeeQuotes bool `json:"use_fee_quotes" mapstructure:"use_fee_quotes"`
 }
 
 // NotificationsConfig is the configuration for notifications

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -118,8 +118,8 @@ func getNodesDefaults() *NodesConfig {
 		Protocol: NodesProtocolArc,
 		Apis: []*MinerAPI{
 			{
-				ArcURL:  "https://arc.gorillapool.io",
-				MapiURL: "https://merchantapi.gorillapool.io",
+				ArcURL: "https://arc.gorillapool.io",
+				// GorillaPool does not support querying (Merkle proofs)
 				Token:   "",
 				MinerID: "03ad780153c47df915b3d2e23af727c68facaca4facd5f155bf5018b979b9aeb83",
 			},

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/mrz1836/go-datastore"
-	"github.com/tonicpow/go-minercraft/v2"
 )
 
 func getDefaultAppConfig() *AppConfig {
@@ -116,10 +115,18 @@ func getNewRelicDefaults() *NewRelicConfig {
 
 func getNodesDefaults() *NodesConfig {
 	return &NodesConfig{
-		UseMapiFeeQuotes:     true,
-		MinercraftAPI:        "mAPI",
-		MinercraftCustomAPIs: []*minercraft.MinerAPIs{},
-		BroadcastClientAPIs:  []*BroadcastClientAPI{},
+		Protocol: NodesProtocolArc,
+		Apis: []*MinerAPI{
+			{
+				ArcURL:  "https://arc.gorillapool.io",
+				MapiURL: "https://merchantapi.gorillapool.io",
+				Token:   "",
+				MinerID: "03ad780153c47df915b3d2e23af727c68facaca4facd5f155bf5018b979b9aeb83",
+			},
+		},
+		Mapi: &MapiConfig{
+			UseFeeQuotes: true,
+		},
 	}
 }
 

--- a/config/nodes.go
+++ b/config/nodes.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"errors"
+
+	broadcastclient "github.com/bitcoin-sv/go-broadcast-client/broadcast/broadcast-client"
+	"github.com/tonicpow/go-minercraft/v2"
+)
+
+// NodesProtocol is the protocol/api_type used to communicate with the miners
+type NodesProtocol string
+
+const (
+	// NodesProtocolMapi represents the mapi protocol provided by minercraft
+	NodesProtocolMapi NodesProtocol = "mapi"
+
+	// NodesProtocolArc represents the arc protocol provided by go-broadcast-client
+	NodesProtocolArc NodesProtocol = "arc"
+)
+
+// Validate whether the protocol is known
+func (n NodesProtocol) Validate() error {
+	switch n {
+	case NodesProtocolMapi, NodesProtocolArc:
+		return nil
+	default:
+		return errors.New("invalid nodes protocol")
+	}
+}
+
+func (nodes *NodesConfig) toMinercraftMapi() []*minercraft.MinerAPIs {
+	minerApis := []*minercraft.MinerAPIs{}
+	if nodes.Apis != nil {
+		for _, api := range nodes.Apis {
+			if api.MapiURL == "" {
+				continue
+			}
+			minerApis = append(minerApis, &minercraft.MinerAPIs{
+				MinerID: api.MinerID,
+				APIs: []minercraft.API{
+					{
+						Token: api.Token,
+						URL:   api.MapiURL,
+						Type:  minercraft.MAPI,
+					},
+				},
+			})
+		}
+	}
+	return minerApis
+}
+
+func (nodes *NodesConfig) toBroadcastClientArc() []*broadcastclient.ArcClientConfig {
+	minerApis := []*broadcastclient.ArcClientConfig{}
+	if nodes.Apis != nil {
+		for _, cfg := range nodes.Apis {
+			if cfg.ArcURL == "" {
+				continue
+			}
+			minerApis = append(minerApis, &broadcastclient.ArcClientConfig{
+				Token:  cfg.Token,
+				APIUrl: cfg.ArcURL,
+			})
+		}
+	}
+	return minerApis
+}

--- a/config/services.go
+++ b/config/services.go
@@ -377,7 +377,6 @@ func loadBroadcastClientArc(appConfig *AppConfig, options []bux.ClientOps, logge
 	broadcastClient := builder.Build()
 	options = append(
 		options,
-		bux.WithArc(),
 		bux.WithBroadcastClient(broadcastClient),
 	)
 	return options

--- a/config/services.go
+++ b/config/services.go
@@ -365,7 +365,12 @@ func loadTaskManager(appConfig *AppConfig, options []bux.ClientOps) []bux.Client
 
 func loadBroadcastClientArc(appConfig *AppConfig, options []bux.ClientOps, logger *zerolog.Logger) []bux.ClientOps {
 	builder := broadcastclient.Builder()
-	bcLogger := logger.With().Str("service", "broadcast-client").Logger()
+	var bcLogger zerolog.Logger
+	if logger == nil {
+		bcLogger = zerolog.Nop()
+	} else {
+		bcLogger = logger.With().Str("service", "broadcast-client").Logger()
+	}
 	for _, arcClient := range appConfig.Nodes.toBroadcastClientArc() {
 		builder.WithArc(*arcClient, &bcLogger)
 	}

--- a/config/services.go
+++ b/config/services.go
@@ -188,7 +188,7 @@ func (s *AppServices) loadBux(ctx context.Context, appConfig *AppConfig, testMod
 	if appConfig.Nodes.Protocol == NodesProtocolMapi {
 		options = loadMinercraftMapi(appConfig, options)
 	} else if appConfig.Nodes.Protocol == NodesProtocolArc {
-		options = loadBroadcastClientArc(appConfig, options)
+		options = loadBroadcastClientArc(appConfig, options, logger)
 	}
 
 	// Create the new client
@@ -363,10 +363,11 @@ func loadTaskManager(appConfig *AppConfig, options []bux.ClientOps) []bux.Client
 	return options
 }
 
-func loadBroadcastClientArc(appConfig *AppConfig, options []bux.ClientOps) []bux.ClientOps {
+func loadBroadcastClientArc(appConfig *AppConfig, options []bux.ClientOps, logger *zerolog.Logger) []bux.ClientOps {
 	builder := broadcastclient.Builder()
+	bcLogger := logger.With().Str("service", "broadcast-client").Logger()
 	for _, arcClient := range appConfig.Nodes.toBroadcastClientArc() {
-		builder.WithArc(*arcClient)
+		builder.WithArc(*arcClient, &bcLogger)
 	}
 	broadcastClient := builder.Build()
 	options = append(

--- a/config/validate_nodes.go
+++ b/config/validate_nodes.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"errors"
+	"slices"
+)
+
+// Validate checks the configuration for specific rules
+func (n *NodesConfig) Validate() error {
+	if n == nil {
+		return errors.New("nodes are not configured")
+	}
+
+	err := n.Protocol.Validate()
+	if err != nil {
+		return err
+	}
+
+	if n.Apis == nil || len(n.Apis) == 0 {
+		return errors.New("no miner apis configured")
+	}
+
+	// check if at least one mapi url is configured
+	if n.Protocol == NodesProtocolMapi {
+		found := slices.IndexFunc(n.Apis, func(el *MinerAPI) bool {
+			return el.MapiURL != ""
+		})
+		if found == -1 {
+			return errors.New("no mapi urls configured")
+		}
+	}
+
+	// check if at least one arc url is configured
+	if n.Protocol == NodesProtocolArc {
+		found := slices.IndexFunc(n.Apis, func(el *MinerAPI) bool {
+			return el.ArcURL != ""
+		})
+		if found == -1 {
+			return errors.New("no arc urls configured")
+		}
+	}
+
+	return nil
+}

--- a/config/validate_nodes_test.go
+++ b/config/validate_nodes_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewRelicConfig_Validate will test the method Validate()
+func TestNodesConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid default nodes config", func(t *testing.T) {
+		n := getNodesDefaults()
+		assert.NoError(t, n.Validate())
+	})
+
+	t.Run("wrong protocol", func(t *testing.T) {
+		n := getNodesDefaults()
+		n.Protocol = "wrong"
+		assert.Error(t, n.Validate())
+	})
+
+	t.Run("empty list of apis", func(t *testing.T) {
+		n := getNodesDefaults()
+
+		n.Apis = nil
+		assert.Error(t, n.Validate())
+
+		n.Apis = []*MinerAPI{}
+		assert.Error(t, n.Validate())
+	})
+
+	t.Run("no mapi url", func(t *testing.T) {
+		n := getNodesDefaults()
+
+		n.Apis = []*MinerAPI{
+			{
+				MapiURL: "",
+			},
+		}
+		assert.Error(t, n.Validate())
+	})
+
+	t.Run("no mapi url", func(t *testing.T) {
+		n := getNodesDefaults()
+
+		n.Protocol = NodesProtocolMapi
+		n.Apis[0].MapiURL = ""
+		assert.Error(t, n.Validate())
+	})
+
+	t.Run("no arc url", func(t *testing.T) {
+		n := getNodesDefaults()
+
+		n.Protocol = NodesProtocolArc
+		n.Apis[0].ArcURL = ""
+		assert.Error(t, n.Validate())
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.5
 
 require (
 	github.com/99designs/gqlgen v0.17.42
-	github.com/BuxOrg/bux v0.10.2
+	github.com/BuxOrg/bux v0.11.0
 	github.com/BuxOrg/bux-models v0.3.0
 	github.com/bitcoin-sv/go-broadcast-client v0.12.0
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.42
 	github.com/BuxOrg/bux v0.11.0
 	github.com/BuxOrg/bux-models v0.3.0
-	github.com/bitcoin-sv/go-broadcast-client v0.12.0
+	github.com/bitcoin-sv/go-broadcast-client v0.12.2
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.42
 	github.com/BuxOrg/bux v0.10.2
 	github.com/BuxOrg/bux-models v0.3.0
-	github.com/bitcoin-sv/go-broadcast-client v0.10.0
+	github.com/bitcoin-sv/go-broadcast-client v0.12.0
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/99designs/gqlgen v0.17.42 h1:BVWDOb2VVHQC5k3m6oa0XhDnxltLLrU4so7x/u39Zu4=
 github.com/99designs/gqlgen v0.17.42/go.mod h1:GQ6SyMhwFbgHR0a8r2Wn8fYgEwPxxmndLFPhU63+cJE=
-github.com/BuxOrg/bux v0.10.2 h1:5/MgxGfLX+wZL95ka6nYoXuJbhg4kEnKHyhH7L560Ug=
-github.com/BuxOrg/bux v0.10.2/go.mod h1:lK+ah2SQjGLhKVvQZvDBkWFN95TRG19+JkOLJkKZlmI=
+github.com/BuxOrg/bux v0.11.0 h1:8kJAN8H/YAe3vCrnPuEakOvi9OZDPGlj/bnwjFDiMK4=
+github.com/BuxOrg/bux v0.11.0/go.mod h1:xwxsYeL726ORudn9DK+PSX2qfpettD7QCTT6gmQ7Drw=
 github.com/BuxOrg/bux-models v0.3.0 h1:+pvpDdYaiIgeOhAO847RK07Vzc+vuUvy2ok/xJevQyg=
 github.com/BuxOrg/bux-models v0.3.0/go.mod h1:JCpoXxVnKZmCy3rg6nOtLQL5AXh6iEo2tBvcD/qAxEY=
 github.com/DATA-DOG/go-sqlmock v1.5.1 h1:FK6RCIUSfmbnI/imIICmboyQBkOckutaa6R5YYlLZyo=
@@ -30,8 +30,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.43.45 h1:2708Bj4uV+ym62MOtBnErm/CDX61C4mFe9V2gXy1caE=
 github.com/aws/aws-sdk-go v1.43.45/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/bitcoin-sv/go-broadcast-client v0.12.0 h1:Ef82ss4G2olFIAfv3xjt6p2zq6HZdlPNg+eOb6R73UE=
-github.com/bitcoin-sv/go-broadcast-client v0.12.0/go.mod h1:BTmakaAihsGffiIc6FjFIe/tEUcsedWs6GbryZXcpX4=
+github.com/bitcoin-sv/go-broadcast-client v0.12.2 h1:1xgYPqc0o0iR4UUs1Rcku5ISa4WyHEGrU1TwzYW7zdk=
+github.com/bitcoin-sv/go-broadcast-client v0.12.2/go.mod h1:BTmakaAihsGffiIc6FjFIe/tEUcsedWs6GbryZXcpX4=
 github.com/bitcoin-sv/go-paymail v0.11.0 h1:jEfBLLaUUIxN3WnkU9d6Wj9IUen1Xx09dWUHlz3gTnQ=
 github.com/bitcoin-sv/go-paymail v0.11.0/go.mod h1:wH4jOVM24y7+OS2rLeJpwzJ73abM2rq/aeKZom0lHSk=
 github.com/bitcoinschema/go-bitcoin/v2 v2.0.5 h1:Sgh5Eb746Zck/46rFDrZZEXZWyO53fMuWYhNoZa1tck=

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.43.45 h1:2708Bj4uV+ym62MOtBnErm/CDX61C4mFe9V2gXy1caE=
 github.com/aws/aws-sdk-go v1.43.45/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/bitcoin-sv/go-broadcast-client v0.10.0 h1:G15Di58APGbBdUu9Z/QiziKImW4sqMQDasLjgNAXGAQ=
-github.com/bitcoin-sv/go-broadcast-client v0.10.0/go.mod h1:VePGovAMTQM6G4kQDyXZkcMKCUm2c5eIgfP+WIvqXg4=
+github.com/bitcoin-sv/go-broadcast-client v0.12.0 h1:Ef82ss4G2olFIAfv3xjt6p2zq6HZdlPNg+eOb6R73UE=
+github.com/bitcoin-sv/go-broadcast-client v0.12.0/go.mod h1:BTmakaAihsGffiIc6FjFIe/tEUcsedWs6GbryZXcpX4=
 github.com/bitcoin-sv/go-paymail v0.11.0 h1:jEfBLLaUUIxN3WnkU9d6Wj9IUen1Xx09dWUHlz3gTnQ=
 github.com/bitcoin-sv/go-paymail v0.11.0/go.mod h1:wH4jOVM24y7+OS2rLeJpwzJ73abM2rq/aeKZom0lHSk=
 github.com/bitcoinschema/go-bitcoin/v2 v2.0.5 h1:Sgh5Eb746Zck/46rFDrZZEXZWyO53fMuWYhNoZa1tck=


### PR DESCRIPTION
<!-- 
    Thank you for contributing to our project! Before you submit your Pull Request, please make sure you've completed the items in this checklist.
    Please check the boxes below by putting an x in the [ ] like so: [x]. You can do it right after creating the PR.
-->

# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/BuxOrg/bux-server/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/BuxOrg/bux-server/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] 🏠 I tested my changes locally.
- [x] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [x] 💾 PR was issued based on the Github or Jira issue.

This PR is tightly coupled with https://github.com/BuxOrg/bux/pull/521 and new `0.12.0 broadcast-client` update. 

The main goal of this task was to explicitly allow the selection of `mapi` or `arc` and to provide default values making it work with `arc - gorillapool`.

The config part - `nodes` has been restructured. Generally, user don't have to configure it at all - because of defaults. 

**Although it compiles and runs with previous `bux` versions - proper functionality will be starting from `bux 0.11.0`**

## How to configure the `nodes` part

If you have previous config which looks like this:
```yaml
nodes:
    broadcast_client_apis: []
    minercraft_api: mAPI
    minercraft_custom_apis: []
```
... the simplest option is - just delete the whole `nodes` part, because it will work using default (`arc - gorillapool`)

If You want to switch to `mapi`, put:
```yaml
nodes:
  protocol: mapi
  apis:
    - arc_url: https://tapi.taal.com/arc
      mapi_url: https://merchantapi.taal.com
      token: token_for_taal_is_required_you_have_to_get_one
      minerid: 03e92d3e5c3f7bd945dfbf48e7a99393b1bfb3f11f380ae30d286e7ff2aec5a270
  mapi:
    use_fee_quotes: true
```
The correct values for `protocol` are: `mapi`, `arc` (lowercase)

To configure `arc` with custom apis:
```yaml
nodes:
  protocol: arc
  apis:
    - arc_url: https://arc.gorillapool.io
      token:
    - arc_url: https://arc.some_other_provider.io
      token: theToken
```
When a token is not required, you can either leave the token field empty or omit it entirely

To hold all configuration parameters to either `mapi` and `arc` and easily switch between these protocols:
```yaml
_nodes:
  protocol: arc #just switch to mapi if you will
  apis:
    - arc_url: https://arc.gorillapool.io
      mapi_url: https://merchantapi.gorillapool.io
      minerid: 03ad780153c47df915b3d2e23af727c68facaca4facd5f155bf5018b979b9aeb83
    - arc_url: https://arc.some_ther_provider.io
      mapi_url: https://merchantapi.some_ther_provider.io
      minerid: some_other_provider_miner_id
      token: token_if_required
  mapi:
    use_fee_quotes: true
```

> I'm gonna add the above config description to our Wiki.

<!-- 
## PR Title as Conventional Commit

Your PR title should also be a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). This will assist us in our release process and in assigning semantic version numbers to releases.
-->

<!-- 
## Related Tickets & Documents

If your changes relate to or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For instance, having the text "closes #1234" would link the current pull request to issue number 1234. And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
-->

<!--
## Feature/Issue Details

Your pull request should be tightly connected to a feature or issue. Ensure that you've covered all necessary pathways and there's a possibility to test code behavior following the issue description or feature specification.
-->
